### PR TITLE
Windows part quantity

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -9,7 +9,8 @@
     <!-- build:css(.) styles/vendor.css -->
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
-    <link rel="stylesheet" href="bower_components/angular-ui-grid/ui-grid.min.css" />
+    <link rel="stylesheet" href="bower_components/ag-grid/dist/angular-grid.css" />
+    <link rel="stylesheet" href="bower_components/ag-grid/dist/theme-fresh.css" />
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:css(.tmp) styles/main.css -->
@@ -80,7 +81,7 @@
     <script src="bower_components/angular-route/angular-route.js"></script>
     <script src="bower_components/underscore/underscore.js"></script>
     <script src="bower_components/jspdf/dist/jspdf.min.js"></script>
-    <script src="bower_components/angular-ui-grid/ui-grid.min.js"></script>
+    <script src="bower_components/ag-grid/dist/angular-grid.min.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -11,8 +11,7 @@
 angular
   .module('longCalculatorApp', [
     'ngRoute',
-    'ui.grid',
-    'ui.grid.edit'
+    'angularGrid'
   ])
   .config(function ($routeProvider) {
     $routeProvider

--- a/app/scripts/controllers/windowsCtrl.js
+++ b/app/scripts/controllers/windowsCtrl.js
@@ -5,9 +5,10 @@ angular.module('longCalculatorApp')
     var removeTemplate = '<i class="glyphicon glyphicon-trash" ng-click="removeRow(row)" />';
     var longColumnsWidth = 70;
     var quantityColumnsWidth = 40;
+    var configurationColumnsWidth = 120;
     
     var windowsData = windowsInfo.getWindows();
-    $scope.configData = windowsInfo.getConfig();
+    var configData = windowsInfo.getConfig();
     
     $scope.gridOptions = {
         columnDefs: [{field: 'remove', headerName: '', group: 'Ventanas', template: removeTemplate, width: 30},
@@ -31,19 +32,15 @@ angular.module('longCalculatorApp')
     };
     
     $scope.configGridOptions = {
-        data: $scope.configData,
-        //enableCellSelection: true,
-        //enableCellEdit: true,
-        //enableRowSelection: false,
-        enableColumnResize: true,
+        rowData: configData,
         
-        columnDefs: [{field: 'property', displayName: 'Propiedad', width: 200},
-                     {field: 'rielSuperior', displayName:'Riel Superior'},
-                     {field: 'rielInferior', displayName:'Riel Inferior'},
-                     {field: 'jamba', displayName:'Jamba'},
-                     {field: 'gancho', displayName:'Gancho'},
-                     {field: 'cabezal', displayName:'Cabezal'},
-                     {field: 'socalo', displayName:'Socalo'}]
+        columnDefs: [{field: 'property', headerName: 'Propiedad', editable: true, width: configurationColumnsWidth},
+                     {field: 'rielSuperior', headerName:'Riel Superior', editable: true, width: configurationColumnsWidth},
+                     {field: 'rielInferior', headerName:'Riel Inferior', editable: true, width: configurationColumnsWidth},
+                     {field: 'jamba', headerName:'Jamba', editable: true, width: configurationColumnsWidth},
+                     {field: 'gancho', headerName:'Gancho', editable: true, width: configurationColumnsWidth},
+                     {field: 'cabezal', headerName:'Cabezal', editable: true, width: configurationColumnsWidth},
+                     {field: 'socalo', headerName:'Socalo', editable: true, width: configurationColumnsWidth}]
         };
     
     $scope.addNewWindow = function() {
@@ -68,11 +65,10 @@ angular.module('longCalculatorApp')
     $scope.removeRow = function(row){
         var index = $scope.windowsData.indexOf(row.entity);
         windowsData.splice(1, 1);
-//        $scope.gridOptions.api.onNewRows();
     }
     
     $scope.saveData = function() {
-        windowsInfo.saveData(windowsData, $scope.configData);
+        windowsInfo.saveData(windowsData, configData);
     }
   });
     

--- a/app/scripts/controllers/windowsCtrl.js
+++ b/app/scripts/controllers/windowsCtrl.js
@@ -2,37 +2,56 @@
 
 angular.module('longCalculatorApp')
   .controller('windowsCtrl', function ($scope, $http, windowsInfo) {
-    var removeTemplate = '<span class="glyphicon glyphicon-trash" ng-click="grid.appScope.removeRow(row)" />';
-
-    $scope.mySelections = [];
+    var removeTemplate = '<i class="glyphicon glyphicon-trash" ng-click="removeRow(row)" />';
+    var longColumnsWidth = 70;
+    var quantityColumnsWidth = 40;
     
     var windowsData = windowsInfo.getWindows();
     
     $scope.gridOptions = {
-        data: windowsData,
-        enableCellSelection: true,
-        enableCellEdit: true,
-        enableRowSelection: false,
-        enableColumnResize: true,
-        
-        columnDefs: [{field: 'remove', displayName: '', cellTemplate: removeTemplate},
-                     {field: 'name', displayName: 'Ventana', width: 200},
-                     {field: 'rielSuperior', displayName:'Riel Superior'},
-                     {field: 'rielInferior', displayName:'Riel Inferior'},
-                     {field: 'jamba', displayName:'Jamba'},
-                     {field: 'gancho', displayName:'Gancho'},
-                     {field: 'cabezal', displayName:'Cabezal'},
-                     {field: 'socalo', displayName:'Socalo'}]
-        };
+        columnDefs: [{field: 'remove', headerName: '', group: 'Ventanas', template: removeTemplate, width: 30},
+                     {field: 'name', headerName: 'Ventana', group: 'Ventanas', editable: true, width: 150},
+                     {field: 'rielSuperior', headerName:'Longitud', group: 'Riel Superior', editable: true, width: longColumnsWidth},
+                     {field: 'rielSuperiorQuantity', headerName:'Nº', group: 'Riel Superior', editable: true, width: quantityColumnsWidth},
+                     {field: 'rielInferior', headerName:'Longitud', group: 'Riel Inferior', editable: true, width: longColumnsWidth},
+                     {field: 'rielInferiorQuantity', headerName:'Nº', group: 'Riel Inferior', editable: true, width: quantityColumnsWidth},
+                     {field: 'jamba', headerName:'Longitud', group: 'Jamba', editable: true, width: longColumnsWidth},
+                     {field: 'jambaQuantity', headerName:'Nº', group: 'Jamba', editable: true, width: quantityColumnsWidth},
+                     {field: 'gancho', headerName:'Longitud', group: 'Gancho', editable: true, width: longColumnsWidth},
+                     {field: 'ganchoQuantity', headerName:'Nº', group: 'Gancho', editable: true, width: quantityColumnsWidth},
+                     {field: 'cabezal', headerName:'Longitud', group: 'Cabezal', editable: true, width: longColumnsWidth},
+                     {field: 'cabezalQuantity', headerName:'Nº', group: 'Cabezal', editable: true, width: quantityColumnsWidth},
+                     {field: 'socalo', headerName:'Longitud', group: 'Socalo', editable: true, width: longColumnsWidth},
+                     {field: 'socaloQuantity', headerName:'Nº', group: 'Socalo', editable: true, width: quantityColumnsWidth}],
+   
+        rowData: windowsData,
+        angularCompileRows: true,
+        groupHeaders: true,
+    };
     
     $scope.addNewWindow = function() {
-        windowsData.push({name: 'Ventana '+windowsInfo.windowNumber, jamba: '', rielSuperior: '', rielInferior: ''});
+        windowsData.push({name: 'Ventana '+windowsInfo.windowNumber,
+                          rielSuperior: '',
+                          rielSuperiorQuantity: '',
+                          rielInferior: '',
+                          rielInferiorQuantity: '',
+                          jamba: '',
+                          jambaQuantity: '',
+                          gancho: '',
+                          ganchoQuantity: '',
+                          cabezal: '',
+                          cabezalQuantity: '',
+                          socalo: '',
+                          socaloQuantity: ''});
+        
         windowsInfo.incrementNumberWindow();
+        $scope.gridOptions.api.onNewRows();
     };
     
     $scope.removeRow = function(row){
-      var index = $scope.gridOptions.data.indexOf(row.entity);
-            $scope.gridOptions.data.splice(index, 1);
+        var index = $scope.windowsData.indexOf(row.entity);
+        windowsData.splice(1, 1);
+//        $scope.gridOptions.api.onNewRows();
     }
     
     $scope.saveData = function() {

--- a/app/styles/windows.css
+++ b/app/styles/windows.css
@@ -1,5 +1,10 @@
 .gridStyle {
     border: 1px solid rgb(212,212,212);
-    width: 860px;
+    width: 844px;
     height: 300px;
+}
+
+.configurationGridStyle {
+    width: 844px;
+    height: 140px; 
 }

--- a/app/styles/windows.css
+++ b/app/styles/windows.css
@@ -1,4 +1,5 @@
 .gridStyle {
     border: 1px solid rgb(212,212,212);
-    height: 300px
+    width: 860px;
+    height: 300px;
 }

--- a/app/views/windows.html
+++ b/app/views/windows.html
@@ -14,8 +14,8 @@
     </br>
     
     <div class="row">        
-        <div class="col-xs-12 col-md-12 col-lg-12">
-            <div class="gridStyle" ui-grid="gridOptions" ui-grid-edit></table>
+        <div class="col-xs-12 col-md-12 col-lg-12 ">
+            <div ag-grid="gridOptions" class="ag-fresh gridStyle"></div>
         </div>
     </div>
 </div>

--- a/app/views/windows.html
+++ b/app/views/windows.html
@@ -23,7 +23,7 @@
     <h3>Configuration</h3>
     <div class="row">        
         <div class="col-xs-12 col-md-12 col-lg-12">
-            <div class="gridStyle" ui-grid="configGridOptions" ui-grid-edit></div>
+            <div ag-grid="configGridOptions" class="ag-fresh configurationGridStyle"></div>
         </div>
     </div>
 </div>

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "angular-route": "^1.3.0",
     "underscore": "~1.8.3",
     "jspdf": "~1.1.135",
-    "angular-ui-grid": "~3.0.0-rc.22"
+    "ag-grid": "~1.10.0"
   },
   "devDependencies": {
     "angular-mocks": "^1.3.0"

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -28,7 +28,7 @@ module.exports = function(config) {
       'bower_components/angular-route/angular-route.js',
       'bower_components/underscore/underscore.js',
       'bower_components/jspdf/dist/jspdf.min.js',
-      'bower_components/angular-ui-grid/ui-grid.js',
+      'bower_components/ag-grid/dist/angular-grid.js',
       'bower_components/angular-mocks/angular-mocks.js',
       // endbower
       "app/scripts/**/*.js",


### PR DESCRIPTION
Using ag-grid instead of angular-ui-grid, it is better to use ag-grid instead of angular-ui-grid because working with subdivisions in the tables is easier.

Added subidvision for the number of the parts of the sticks so the user can add more longs just with one value.

Fixing configuration table in windows view.
